### PR TITLE
Flight validation for stored airports

### DIFF
--- a/back-end/flight_app/validators.py
+++ b/back-end/flight_app/validators.py
@@ -25,12 +25,8 @@ def validate_pilot_responsible(pilot_responsible: str) -> str:
 
 
 def validate_origin(origin: str) -> str:
-    # take in origin code
-    # grab all instances of airports from Airport model and store all codes as list
-    # iterate over list and if origin input matches airport code, return
-    # else raise ValidationError that code is not in existing airport storage
     error_message = f'{origin} must be a valid airport code.'
-    regex = r'^[A-Z]+$'
+    regex = r'^[A-Z]{4}$'
     good_name = re.match(regex, origin)
     if good_name:
         return good_name
@@ -39,7 +35,7 @@ def validate_origin(origin: str) -> str:
 
 def validate_destination(destination: str) -> str:
     error_message = f'{destination} must be a valid airport code.'
-    regex = r'^[A-Z]+$'
+    regex = r'^[A-Z]{4}$'
     good_name = re.match(regex, destination)
     if good_name:
         return good_name

--- a/back-end/flight_app/views.py
+++ b/back-end/flight_app/views.py
@@ -5,8 +5,9 @@ from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_204_NO_CONTENT,
-    HTTP_400_BAD_REQUEST
+    HTTP_400_BAD_REQUEST,
 )
+import json
 from .models import Flight, Brief, Hazard
 from .serializers import FlightSerializer, BriefSerializer, HazardSerializer
 from user_app.views import TokenReq
@@ -21,6 +22,12 @@ class All_flights(TokenReq):
     def post(self, request):
         data = request.data.copy()
         data['user'] = request.user.id
+        lst_of_codes = [
+            airport.icao_code for airport in request.user.airports.all()]
+        if data.get("origin") not in lst_of_codes:
+            return Response(json.dumps({'Error': 'Origin code not found in your stored airport codes.'}), status=HTTP_400_BAD_REQUEST)
+        if data.get("destination") not in lst_of_codes:
+            return Response(json.dumps({'Error': 'Destination code not found in your stored airport codes.'}), status=HTTP_400_BAD_REQUEST)
         new_flight = FlightSerializer(data=data)
         if new_flight.is_valid():
             new_flight.save()

--- a/back-end/tests/test_flight_views.py
+++ b/back-end/tests/test_flight_views.py
@@ -16,13 +16,53 @@ class Test_flight_crud(APITestCase):
             content_type="application/json"
         )
         self.client.cookies = sign_up_response.client.cookies
+        airport_one_post_response = self.client.post(
+            reverse("all_airports"),
+            data=json.dumps({
+                "name": "Savannah",
+                "icao_code": "KSVN"
+            }),
+            content_type="application/json"
+        )
+        airport_two_post_response = self.client.post(
+            reverse("all_airports"),
+            data=json.dumps({
+                "name": "Charleston",
+                "icao_code": "KCHS"
+            }),
+            content_type="application/json"
+        )
+    
+    # Test post method with invalid destination
+    def test_000_all_flights_post_with_invalid_airport_code(self):
+        answer = json.dumps({
+            "Error": "Destination code not found in your stored airport codes."
+        })
+        response = self.client.post(
+            reverse("all_flights"),
+            data=json.dumps({
+                "tail_number": 459,
+                "aircraft_type_model": "CH-47F",
+                "pilot_responsible": "CW2 Chump Nerd",
+                "origin": "KSVN",
+                "destination": "EVGA",
+                "flight_level": 3000,
+                "takeoff_time": "2024-04-08T10:00:00Z",
+                "arrival_time": "2024-04-08T13:00:00Z"
+            }),
+            content_type="application/json"
+        )
+        with self.subTest():
+            self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content), answer)
 
+        
     # Test post method on all_flights view
 
     def test_001_all_flights_post(self):
         answer = {
             "id": 1,
-            "user": 1,
+            "user": 2,
             "tail_number": 459,
             "aircraft_type_model": "CH-47F",
             "pilot_responsible": "CW2 Chump Nerd",
@@ -50,13 +90,14 @@ class Test_flight_crud(APITestCase):
         with self.subTest():
             self.assertEqual(response.status_code, 201)
         self.assertEqual(json.loads(response.content), answer)
+    
 
     # Test get method on all_flights view
 
     def test_002_all_flights_get(self):
         answer = [{
             "id": 2,
-            "user": 2,
+            "user": 3,
             "tail_number": 459,
             "aircraft_type_model": "CH-47F",
             "pilot_responsible": "CW2 Chump Nerd",
@@ -89,7 +130,7 @@ class Test_flight_crud(APITestCase):
     def test_003_a_flight_get(self):
         answer = {
             "id": 3,
-            "user": 3,
+            "user": 4,
             "tail_number": 459,
             "aircraft_type_model": "CH-47F",
             "pilot_responsible": "CW2 Chump Nerd",
@@ -122,7 +163,7 @@ class Test_flight_crud(APITestCase):
     def test_004_a_flight_put(self):
         answer = {
             "id": 4,
-            "user": 4,
+            "user": 5,
             "tail_number": 459,
             "aircraft_type_model": "CH-47F",
             "pilot_responsible": "CW2 Chump Nerd",
@@ -192,6 +233,22 @@ class Test_g_brief_crud(APITestCase):
             content_type="application/json"
         )
         self.client.cookies = sign_up_response.client.cookies
+        airport_one_post_response = self.client.post(
+            reverse("all_airports"),
+            data=json.dumps({
+                "name": "Savannah",
+                "icao_code": "KSVN"
+            }),
+            content_type="application/json"
+        )
+        airport_two_post_response = self.client.post(
+            reverse("all_airports"),
+            data=json.dumps({
+                "name": "Charleston",
+                "icao_code": "KCHS"
+            }),
+            content_type="application/json"
+        )
         flight_post_response = self.client.post(
             reverse("all_flights"),
             data=json.dumps({
@@ -390,6 +447,22 @@ class Test_h_hazard_crud(APITestCase):
             content_type="application/json"
         )
         self.client.cookies = sign_up_response.client.cookies
+        airport_one_post_response = self.client.post(
+            reverse("all_airports"),
+            data=json.dumps({
+                "name": "Savannah",
+                "icao_code": "KSVN"
+            }),
+            content_type="application/json"
+        )
+        airport_two_post_response = self.client.post(
+            reverse("all_airports"),
+            data=json.dumps({
+                "name": "Charleston",
+                "icao_code": "KCHS"
+            }),
+            content_type="application/json"
+        )
         flight_post_response = self.client.post(
             reverse("all_flights"),
             data=json.dumps({


### PR DESCRIPTION
Added extra layer of validation to all_flights view that only allows users to create flights with origins and destinations in their stored airports. If they have not stored the airport they intend to input, it will throw an error, and they need to add it to their airports.